### PR TITLE
Feature/debounce events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,8 +7,9 @@ module.exports = {
     'arrow-body-style': ['error', 'as-needed'],
     'no-plusplus': 'off',
     'no-param-reassign': 'off',
-    'no-underscore-dangle': 'off',
     'no-prototype-builtins': 'off',
+    'no-restricted-properties': 'off',
+    'no-underscore-dangle': 'off',
     'array-callback-return': 'off',
     'no-console': ['error', { allow: ['error'] }],
     'class-methods-use-this': 'off'

--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -13,7 +13,7 @@ describe('Event', () => {
     expect(TestEvent.reducerName).toEqual('TEST_EVENT');
     expect(TestEvent.listenTo).toEqual([]);
     expect(TestEvent.debounce).toEqual(false);
-    expect(TestEvent.debounceDuration).toEqual(500);
+    expect(TestEvent.debounceDelay).toEqual(300);
 
     const mockEvent = jest.fn(() => 'event');
     const listenTo = [{ event: mockEvent, triggerOn: 'dispatch' }];
@@ -22,7 +22,7 @@ describe('Event', () => {
       manager: { initialState: { initial: 'state' } },
       listenTo,
       debounce: true,
-      debounceDuration: 200,
+      debounceDelay: 200,
     });
     expect(TestEvent.name).toEqual('testEvent');
     expect(TestEvent.manager).toEqual({ initialState: { initial: 'state' } });
@@ -30,7 +30,7 @@ describe('Event', () => {
     expect(TestEvent.reducerName).toEqual('TEST_EVENT');
     expect(TestEvent.listenTo).toEqual(listenTo);
     expect(TestEvent.debounce).toEqual(true);
-    expect(TestEvent.debounceDuration).toEqual(200);
+    expect(TestEvent.debounceDelay).toEqual(200);
   });
 
   it('should throw an error when initializing with Empty', async () => {
@@ -49,9 +49,8 @@ describe('Event', () => {
 
   it('should throw error when initializing with debounce true and non number duration', async () => {
     expect(
-      () =>
-        new Event({ name: 'testEvent', manager: {}, debounce: true, debounceDuration: 'wrong' }),
-    ).toThrow('When debounce is true, debounceDuration needs to be a Number.');
+      () => new Event({ name: 'testEvent', manager: {}, debounce: true, debounceDelay: 'wrong' }),
+    ).toThrow('When debounce is true, debounceDelay needs to be a Number.');
   });
 
   it('should throw error when initializing with invalid listenTo param', async () => {
@@ -106,10 +105,10 @@ describe('Event', () => {
     const TestEvent = new Event({ name: 'testEvent', manager: {}, debounce: true });
 
     expect(TestEvent._callRedux('test')).toEqual('test');
-    expect(mockedDebounce).toHaveBeenCalledWith(expect.any(Function), TestEvent.debounceDuration);
+    expect(mockedDebounce).toHaveBeenCalledWith(expect.any(Function), TestEvent.debounceDelay);
   });
 
-  it('debounced _callRedux should use passed debounceDuration if debouce is true', async () => {
+  it('debounced _callRedux should use passed debounceDelay if debouce is true', async () => {
     const mockedDebounce = jest.fn(() => data => data);
     __RewireAPI__.__Rewire__('_debounce', mockedDebounce);
 
@@ -117,7 +116,7 @@ describe('Event', () => {
       name: 'testEvent',
       manager: {},
       debounce: true,
-      debounceDuration: 200,
+      debounceDelay: 200,
     });
 
     expect(TestEvent._callRedux('test')).toEqual('test');

--- a/dist/events.js
+++ b/dist/events.js
@@ -7,6 +7,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.HTTPEvent = exports.Event = void 0;
 
+var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
+
+var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
+
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
 
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
@@ -17,6 +21,16 @@ var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/cl
 
 var _reactRedux = require("react-redux");
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2.default)(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+var _debounce = require('lodash.debounce');
+
+var isNumber = function isNumber(n) {
+  return !window.isNaN(parseFloat(n)) && !window.isNaN(n - 0);
+};
+
 var Event = function Event() {
   var _this = this;
 
@@ -24,20 +38,14 @@ var Event = function Event() {
       _name = _ref.name,
       manager = _ref.manager,
       useDataFrom = _ref.useDataFrom,
+      _ref$debounce = _ref.debounce,
+      debounce = _ref$debounce === void 0 ? false : _ref$debounce,
+      _ref$debounceDuration = _ref.debounceDuration,
+      debounceDuration = _ref$debounceDuration === void 0 ? 500 : _ref$debounceDuration,
       _ref$listenTo = _ref.listenTo,
       _listenTo = _ref$listenTo === void 0 ? [] : _ref$listenTo;
 
   (0, _classCallCheck2.default)(this, Event);
-
-  this.toRedux = function (dispatchData) {
-    return {
-      type: _this.reducerName,
-      shouldDispatch: _this.manager.shouldDispatch || function () {
-        return true;
-      },
-      extraData: dispatchData
-    };
-  };
 
   this.createReducers = function () {
     var reducers = {};
@@ -89,8 +97,10 @@ var Event = function Event() {
   };
 
   this._chainEvents = function (action) {
+    // eslint-disable-next-line camelcase
     var listenTo = _this.listenTo,
-        toRedux = _this.toRedux;
+        _formatToRedux = _this._formatToRedux,
+        __UNSAFE_reduxDispatch = _this.__UNSAFE_reduxDispatch;
 
     if (listenTo.length) {
       listenTo.map(function (_ref3) {
@@ -101,16 +111,24 @@ var Event = function Event() {
 
         if (action.type === reducer) {
           setTimeout(function () {
-            return action.__UNSAFE_dispatch(toRedux(event.__UNSAFE_state));
+            return __UNSAFE_reduxDispatch(_formatToRedux(event.__UNSAFE_state));
           });
         }
       });
     }
   };
 
-  this._dispatch = function (reduxDispatch) {
-    return function (dispatchData) {
-      return reduxDispatch(_this.toRedux(dispatchData));
+  this._callRedux = function (dispatchData) {
+    return _this.__UNSAFE_reduxDispatch(_this._formatToRedux(dispatchData));
+  };
+
+  this._formatToRedux = function (dispatchData) {
+    return {
+      type: _this.reducerName,
+      shouldDispatch: _this.manager.shouldDispatch || function () {
+        return true;
+      },
+      extraData: dispatchData
     };
   };
 
@@ -132,8 +150,9 @@ var Event = function Event() {
   };
 
   this._bindDispatchToProps = function (reduxDispatch) {
+    _this.__UNSAFE_reduxDispatch = reduxDispatch;
     var actions = {};
-    actions[_this.name] = _this._dispatch(reduxDispatch);
+    actions[_this.name] = _this._callRedux;
     return actions;
   };
 
@@ -161,12 +180,22 @@ var Event = function Event() {
     }
   }
 
+  if (debounce && !isNumber(debounceDuration)) {
+    throw new Error('When debounce is true, debounceDuration needs to be a Number.');
+  }
+
   this.name = _name;
   this.manager = manager;
+  this.debounce = debounce;
+  this.debounceDuration = debounceDuration;
   this.listenTo = _listenTo;
   this.useDataFrom = useDataFrom;
   this.__UNSAFE_state = manager.initialState;
   this.reducerName = this._formatReducerName(this.name);
+
+  if (this.debounce) {
+    this._callRedux = _debounce(this._callRedux, this.debounceDuration);
+  }
 };
 
 exports.Event = Event;
@@ -181,20 +210,14 @@ function (_Event) {
 
     var _ref4 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
         name = _ref4.name,
-        manager = _ref4.manager,
-        useDataFrom = _ref4.useDataFrom,
-        _ref4$listenTo = _ref4.listenTo,
-        listenTo = _ref4$listenTo === void 0 ? [] : _ref4$listenTo;
+        rest = (0, _objectWithoutProperties2.default)(_ref4, ["name"]);
 
     (0, _classCallCheck2.default)(this, HTTPEvent);
-    _this2 = (0, _possibleConstructorReturn2.default)(this, (0, _getPrototypeOf2.default)(HTTPEvent).call(this, {
-      name: name,
-      manager: manager,
-      useDataFrom: useDataFrom,
-      listenTo: listenTo
-    }));
+    _this2 = (0, _possibleConstructorReturn2.default)(this, (0, _getPrototypeOf2.default)(HTTPEvent).call(this, _objectSpread({
+      name: name
+    }, rest)));
 
-    _this2.toRedux = function (dispatchData) {
+    _this2._formatToRedux = function (dispatchData) {
       var shouldDispatch = _this2.manager.shouldDispatch;
       return {
         types: _this2.reducers,

--- a/dist/events.js
+++ b/dist/events.js
@@ -40,8 +40,8 @@ var Event = function Event() {
       useDataFrom = _ref.useDataFrom,
       _ref$debounce = _ref.debounce,
       debounce = _ref$debounce === void 0 ? false : _ref$debounce,
-      _ref$debounceDuration = _ref.debounceDuration,
-      debounceDuration = _ref$debounceDuration === void 0 ? 500 : _ref$debounceDuration,
+      _ref$debounceDelay = _ref.debounceDelay,
+      debounceDelay = _ref$debounceDelay === void 0 ? 300 : _ref$debounceDelay,
       _ref$listenTo = _ref.listenTo,
       _listenTo = _ref$listenTo === void 0 ? [] : _ref$listenTo;
 
@@ -180,21 +180,21 @@ var Event = function Event() {
     }
   }
 
-  if (debounce && !isNumber(debounceDuration)) {
-    throw new Error('When debounce is true, debounceDuration needs to be a Number.');
+  if (debounce && !isNumber(debounceDelay)) {
+    throw new Error('When debounce is true, debounceDelay needs to be a Number.');
   }
 
   this.name = _name;
   this.manager = manager;
   this.debounce = debounce;
-  this.debounceDuration = debounceDuration;
+  this.debounceDelay = debounceDelay;
   this.listenTo = _listenTo;
   this.useDataFrom = useDataFrom;
   this.__UNSAFE_state = manager.initialState;
   this.reducerName = this._formatReducerName(this.name);
 
   if (this.debounce) {
-    this._callRedux = _debounce(this._callRedux, this.debounceDuration);
+    this._callRedux = _debounce(this._callRedux, this.debounceDelay);
   }
 };
 

--- a/docs/3-Advanced-Usage.md
+++ b/docs/3-Advanced-Usage.md
@@ -21,6 +21,52 @@ export class ExampleEventManager {
 
 ```
 
+### Debouncing Events
+
+It's not unusual to have a use case in which you don't really want to trigger the Event right away. When the user is typing some data into a text input, for example, we may want to wait for a certein amount of time so that the user has finished typing, and only then trigger the Event with the latest data.
+
+Doing that inside a component may give you some undesirable effects. First of all the Component will need to implement the debouncing itself, and more code is more windows for errors. The redux flow will be oh so slightly off from the input change as well, which may lead to rendering issues when presenting the loading spinner, for example.
+
+To deal with those cases, we provide an optional `debounce` and `debounceDelay` configurations. When instantiating the Event, you are able to do something like this:
+
+```js
+// on events.js
+import { HTTPEvent } from 'rel-events';
+import { SearchByUsernameHTTPEventManager } from './eventManagers.js';
+
+export const SearchByUsernameHTTPEvent = new HTTPEvent({
+  name: 'searchByUsername',
+  manager: new SearchByUsernameHTTPEventManager(),
+  // we set debounce as true and optionally pass a custom delay in ms
+  debounce: true,
+  debounceDelay: 500, // defaults to 300
+});
+```
+
+Then, just trigger the Event as you would before and the Event will wait for that amount of time before dispatching itself:
+
+
+```js
+// on SearchByUsernameComponent.js
+import { SearchByUsernameHTTPEvent } from './events.js';
+
+class SearchByUsernameComponent extends React.Component {
+  //...
+
+  // even though the Event will be triggered whenever something is typed,
+  // it will only be dispatched after the user stopped typing
+  // and 500ms has passed since the last edit
+  render() {
+    return <inpyt type="text" onChange={e => this.props.searchByUsername({ username: e.target.value })} />
+  };
+  // ...
+}
+
+export default LoginHTTPEvent.register({ Component: LoginComponent });
+```
+
+The debounce function is provided straight from [lodash](https://lodash.com/docs/4.17.15#debounce).
+
 ### Event Chaining - Making Events listen to Events
 
 Sometimes, we want to make an Event be triggered by the completion of another. Let's imagine that, after logging in an user, we need to go somewhere to get the user's data.

--- a/docs/4-API-docs.md
+++ b/docs/4-API-docs.md
@@ -23,6 +23,8 @@ new Event({
   manager: Object.isRequired,
   useDataFrom: String,
   listenTo: Array.of(Object),
+  debounce: Boolean,
+  debounceDelay: Number,
 });
 
 // example:
@@ -37,7 +39,9 @@ const ChooseDateRangeEvent = new Event({
       event: () => Event/HTTPEvent instance,
       triggerOn: String(depends on the event being listened: 'dispatch' for normal Events, 'dispatch'/'success'/'failure' for HTTPEvents)
     }
-  ]
+  ],
+  debounce: true,
+  debounceDelay: 500,
 });
 ```
 
@@ -103,19 +107,6 @@ export default combineReducers({
   ...ChooseDateRangeEvent.createReducers(),
   // returns { 'chooseDateRange': (state, action) => { ... } }
 });
-```
-
-### Event.toRedux
-
-"Serializes" data in a way that redux knows how to dispatch. Receives an object and returns an object. Mostly used internally. Unsafe.
-
-```js
-EventInstance.toRedux({ data });
-// returns an object of { type: formatted event.name, shouldDispatch: Function -> Boolean,  ...data }
-
-// example:
-ChooseDateRangeEvent.toRedux({ startDate: new Date, endDate: new Date });
-// returns { type: 'CHOOSE_DATE_RANGE', shouldDispatch: () => true, startDate, endDate }
 ```
 
 ---------------------------------------

--- a/lib/events.js
+++ b/lib/events.js
@@ -10,7 +10,7 @@ export class Event {
     manager,
     useDataFrom,
     debounce = false,
-    debounceDuration = 500,
+    debounceDelay = 300,
     listenTo = [],
   } = {}) {
     if (arguments.length === 0) {
@@ -39,21 +39,21 @@ export class Event {
       }
     }
 
-    if (debounce && !isNumber(debounceDuration)) {
-      throw new Error('When debounce is true, debounceDuration needs to be a Number.');
+    if (debounce && !isNumber(debounceDelay)) {
+      throw new Error('When debounce is true, debounceDelay needs to be a Number.');
     }
 
     this.name = name;
     this.manager = manager;
     this.debounce = debounce;
-    this.debounceDuration = debounceDuration;
+    this.debounceDelay = debounceDelay;
     this.listenTo = listenTo;
     this.useDataFrom = useDataFrom;
     this.__UNSAFE_state = manager.initialState;
     this.reducerName = this._formatReducerName(this.name);
 
     if (this.debounce) {
-      this._callRedux = _debounce(this._callRedux, this.debounceDuration);
+      this._callRedux = _debounce(this._callRedux, this.debounceDelay);
     }
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,7 +1,18 @@
 import { connect } from 'react-redux';
 
+const _debounce = require('lodash.debounce');
+
+const isNumber = n => !window.isNaN(parseFloat(n)) && !window.isNaN(n - 0);
+
 export class Event {
-  constructor({ name, manager, useDataFrom, listenTo = [] } = {}) {
+  constructor({
+    name,
+    manager,
+    useDataFrom,
+    debounce = false,
+    debounceDuration = 500,
+    listenTo = [],
+  } = {}) {
     if (arguments.length === 0) {
       throw new Error('An Event should not be initialized without parameters.');
     } else {
@@ -27,19 +38,24 @@ export class Event {
         );
       }
     }
+
+    if (debounce && !isNumber(debounceDuration)) {
+      throw new Error('When debounce is true, debounceDuration needs to be a Number.');
+    }
+
     this.name = name;
     this.manager = manager;
+    this.debounce = debounce;
+    this.debounceDuration = debounceDuration;
     this.listenTo = listenTo;
     this.useDataFrom = useDataFrom;
     this.__UNSAFE_state = manager.initialState;
     this.reducerName = this._formatReducerName(this.name);
-  }
 
-  toRedux = dispatchData => ({
-    type: this.reducerName,
-    shouldDispatch: this.manager.shouldDispatch || (() => true),
-    extraData: dispatchData,
-  });
+    if (this.debounce) {
+      this._callRedux = _debounce(this._callRedux, this.debounceDuration);
+    }
+  }
 
   createReducers = () => {
     const reducers = {};
@@ -80,7 +96,8 @@ export class Event {
   };
 
   _chainEvents = action => {
-    const { listenTo, toRedux } = this;
+    // eslint-disable-next-line camelcase
+    const { listenTo, _formatToRedux, __UNSAFE_reduxDispatch } = this;
 
     if (listenTo.length) {
       listenTo.map(({ event, triggerOn }) => {
@@ -88,13 +105,19 @@ export class Event {
         const reducer = event.reducerName ? event.reducerName : event.reducers[triggerOn];
 
         if (action.type === reducer) {
-          setTimeout(() => action.__UNSAFE_dispatch(toRedux(event.__UNSAFE_state)));
+          setTimeout(() => __UNSAFE_reduxDispatch(_formatToRedux(event.__UNSAFE_state)));
         }
       });
     }
   };
 
-  _dispatch = reduxDispatch => dispatchData => reduxDispatch(this.toRedux(dispatchData));
+  _callRedux = dispatchData => this.__UNSAFE_reduxDispatch(this._formatToRedux(dispatchData));
+
+  _formatToRedux = dispatchData => ({
+    type: this.reducerName,
+    shouldDispatch: this.manager.shouldDispatch || (() => true),
+    extraData: dispatchData,
+  });
 
   _bindDataToProps = props => {
     if (this.useDataFrom && props.length) {
@@ -118,8 +141,9 @@ export class Event {
   };
 
   _bindDispatchToProps = reduxDispatch => {
+    this.__UNSAFE_reduxDispatch = reduxDispatch;
     const actions = {};
-    actions[this.name] = this._dispatch(reduxDispatch);
+    actions[this.name] = this._callRedux;
     return actions;
   };
 
@@ -131,8 +155,8 @@ export class Event {
 }
 
 export class HTTPEvent extends Event {
-  constructor({ name, manager, useDataFrom, listenTo = [] } = {}) {
-    super({ name, manager, useDataFrom, listenTo });
+  constructor({ name, ...rest } = {}) {
+    super({ name, ...rest });
 
     delete this.reducerName;
 
@@ -143,7 +167,7 @@ export class HTTPEvent extends Event {
     };
   }
 
-  toRedux = dispatchData => {
+  _formatToRedux = dispatchData => {
     const { shouldDispatch } = this.manager;
     return {
       types: this.reducers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "rel-events",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.4.tgz",
-      "integrity": "sha512-O7mmzaWdm+VabWQmxuM8hqNrWGGihN83KfhPUzp2lAW4kzIMwBxujXkZbD4fMwKMYY9FXTbDvXsJqU+5XHXi4A==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.7.tgz",
+      "integrity": "sha512-XQw5KyCZyu/M8/0rYiZyuwbgIQNzOrJzs9dDLX+MieSgBwTLvTj4QVbLmxJACAIvQIDT7PtyHN2sC48EOWTgaA==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.8",
@@ -31,15 +31,15 @@
       }
     },
     "@babel/core": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
-      "integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
+      "integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
+        "@babel/generator": "^7.7.7",
         "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/parser": "^7.7.7",
         "@babel/template": "^7.7.4",
         "@babel/traverse": "^7.7.4",
         "@babel/types": "^7.7.4",
@@ -70,9 +70,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-      "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.7.4",
@@ -204,9 +204,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz",
-      "integrity": "sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+      "integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -320,9 +320,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-      "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -367,9 +367,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
-      "integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
+      "integrity": "sha512-3qp9I8lelgzNedI3hrhkvhaEYree6+WHnyA/q4Dza9z7iEIs1eyhWyJnetk3jJ69RT0AT4G0UhEGwyGFJ7GUuQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -387,9 +387,9 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
-      "integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
+      "integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
@@ -524,9 +524,9 @@
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
-      "integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
+      "integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
@@ -590,23 +590,23 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.4.tgz",
-      "integrity": "sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+      "integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.7.4",
+        "@babel/helper-module-transforms": "^7.7.5",
         "@babel/helper-plugin-utils": "^7.0.0",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz",
-      "integrity": "sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+      "integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.7.4",
+        "@babel/helper-module-transforms": "^7.7.5",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-simple-access": "^7.7.4",
         "babel-plugin-dynamic-import-node": "^2.3.0"
@@ -662,9 +662,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
-      "integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
+      "integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.7.4",
@@ -682,9 +682,9 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.4.tgz",
-      "integrity": "sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+      "integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.0"
@@ -700,9 +700,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
-      "integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
+      "integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -769,9 +769,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",
-      "integrity": "sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.7.tgz",
+      "integrity": "sha512-pCu0hrSSDVI7kCVUOdcMNQEbOPJ52E+LrQ14sN8uL2ALfSqePZQlKrOy+tM4uhEdYlCHi4imr8Zz2cZe9oSdIg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -779,9 +779,9 @@
         "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
         "@babel/plugin-proposal-dynamic-import": "^7.7.4",
         "@babel/plugin-proposal-json-strings": "^7.7.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.7.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
         "@babel/plugin-syntax-async-generators": "^7.7.4",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
         "@babel/plugin-syntax-json-strings": "^7.7.4",
@@ -795,23 +795,23 @@
         "@babel/plugin-transform-classes": "^7.7.4",
         "@babel/plugin-transform-computed-properties": "^7.7.4",
         "@babel/plugin-transform-destructuring": "^7.7.4",
-        "@babel/plugin-transform-dotall-regex": "^7.7.4",
+        "@babel/plugin-transform-dotall-regex": "^7.7.7",
         "@babel/plugin-transform-duplicate-keys": "^7.7.4",
         "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
         "@babel/plugin-transform-for-of": "^7.7.4",
         "@babel/plugin-transform-function-name": "^7.7.4",
         "@babel/plugin-transform-literals": "^7.7.4",
         "@babel/plugin-transform-member-expression-literals": "^7.7.4",
-        "@babel/plugin-transform-modules-amd": "^7.7.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.7.4",
+        "@babel/plugin-transform-modules-amd": "^7.7.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.7.5",
         "@babel/plugin-transform-modules-systemjs": "^7.7.4",
         "@babel/plugin-transform-modules-umd": "^7.7.4",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
         "@babel/plugin-transform-new-target": "^7.7.4",
         "@babel/plugin-transform-object-super": "^7.7.4",
-        "@babel/plugin-transform-parameters": "^7.7.4",
+        "@babel/plugin-transform-parameters": "^7.7.7",
         "@babel/plugin-transform-property-literals": "^7.7.4",
-        "@babel/plugin-transform-regenerator": "^7.7.4",
+        "@babel/plugin-transform-regenerator": "^7.7.5",
         "@babel/plugin-transform-reserved-words": "^7.7.4",
         "@babel/plugin-transform-shorthand-properties": "^7.7.4",
         "@babel/plugin-transform-spread": "^7.7.4",
@@ -821,16 +821,16 @@
         "@babel/plugin-transform-unicode-regex": "^7.7.4",
         "@babel/types": "^7.7.4",
         "browserslist": "^4.6.0",
-        "core-js-compat": "^3.1.1",
+        "core-js-compat": "^3.6.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -1116,9 +1116,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
-      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -1181,9 +1181,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
-      "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
+      "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -1328,13 +1328,14 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
       }
     },
     "array-unique": {
@@ -1342,6 +1343,16 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -1477,9 +1488,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -1604,6 +1615,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1667,14 +1688,14 @@
       }
     },
     "browserslist": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.3.tgz",
-      "integrity": "sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
+      "integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001010",
-        "electron-to-chromium": "^1.3.306",
-        "node-releases": "^1.1.40"
+        "caniuse-lite": "^1.0.30001017",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.44"
       }
     },
     "bser": {
@@ -1748,9 +1769,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001012",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001012.tgz",
-      "integrity": "sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg==",
+      "version": "1.0.30001020",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+      "integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==",
       "dev": true
     },
     "capture-exit": {
@@ -1927,9 +1948,9 @@
       }
     },
     "commander": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
-      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
       "dev": true
     },
     "component-emitter": {
@@ -1972,19 +1993,19 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.5.tgz",
-      "integrity": "sha512-rYVvzvKJDKoefdAC+q6VP63vp5hMmeVONCi9pVUbU1qRrtVrmAk/nPhnRg+i+XFd775m1hpG2Yd5RY3X45ccuw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.2.tgz",
+      "integrity": "sha512-+G28dzfYGtAM+XGvB1C5AS1ZPKfQ47HLhcdeIQdZgQnJVdp7/D0m+W/TErwhgsX6CujRUk/LebB6dCrKrtJrvQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.7.3",
-        "semver": "^6.3.0"
+        "browserslist": "^4.8.3",
+        "semver": "7.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
       }
@@ -2243,9 +2264,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.314",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.314.tgz",
-      "integrity": "sha512-IKDR/xCxKFhPts7h+VaSXS02Z1mznP3fli1BbXWXeN89i2gCzKraU8qLpEid8YzKcmZdZD3Mly3cn5/lY9xsBQ==",
+      "version": "1.3.329",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.329.tgz",
+      "integrity": "sha512-CoyYGbkQLwmOpaWRUZgeSNnEPH5fE5R8T7dhQIWV/rlIt+Kx6NFppQJ2oHELmzw8ZGabOBY5CrjGjyA+74QVoQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -2273,21 +2294,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -2308,9 +2330,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
+      "integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -2336,9 +2358,9 @@
       }
     },
     "eslint": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.1.tgz",
-      "integrity": "sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2433,9 +2455,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.7.0.tgz",
-      "integrity": "sha512-FamQVKM3jjUVwhG4hEMnbtsq7xOIDm+SY5iBPfR8gKsJoAB2IQnNF+bk1+8Fy44Nq7PPJaLvkRxILYdJWoguKQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.9.0.tgz",
+      "integrity": "sha512-k4E14HBtcLv0uqThaI6I/n1LEqROp8XaPu6SO9Z32u5NlGRC07Enu1Bh2KEFw4FNHbekH8yzbIU9kUGxbiGmCA==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -2452,32 +2474,33 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
+      "integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
+      "integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
+        "array.prototype.flat": "^1.2.1",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.0",
+        "eslint-module-utils": "^2.4.1",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
         "object.values": "^1.1.0",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "doctrine": {
@@ -2493,9 +2516,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
-      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -2771,9 +2794,9 @@
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2783,12 +2806,12 @@
       "dev": true
     },
     "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.1.1"
       }
     },
     "figures": {
@@ -2808,6 +2831,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2903,14 +2933,15 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -2958,7 +2989,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2988,7 +3019,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3015,12 +3046,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -3046,7 +3077,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3075,7 +3106,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3094,7 +3125,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3136,7 +3167,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3146,12 +3177,12 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -3164,24 +3195,24 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3195,7 +3226,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -3209,13 +3240,22 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3286,7 +3326,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3327,7 +3367,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3354,7 +3394,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3407,18 +3447,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -3443,7 +3483,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3554,9 +3594,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.6.0.tgz",
+      "integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3722,9 +3762,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3853,9 +3893,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3910,9 +3950,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
+      "integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -3924,7 +3964,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -3982,9 +4022,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-ci": {
@@ -4017,9 +4057,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-descriptor": {
@@ -4116,18 +4156,24 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-symbol": {
@@ -4938,6 +4984,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5021,18 +5072,18 @@
       }
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -5182,9 +5233,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
-      "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
+      "version": "1.1.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
+      "integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -5309,25 +5360,25 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -5340,13 +5391,13 @@
       }
     },
     "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
@@ -5675,9 +5726,9 @@
       }
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
       "dev": true
     },
     "pump": {
@@ -5779,9 +5830,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -5816,9 +5867,9 @@
       }
     },
     "redux": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
-      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
@@ -5892,9 +5943,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+      "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
@@ -5987,9 +6038,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -6071,9 +6122,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -6346,12 +6397,12 @@
       "dev": true
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -6529,9 +6580,9 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -6539,9 +6590,9 @@
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -6695,9 +6746,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6911,9 +6962,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
-      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+      "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7311,9 +7362,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "NODE_ENV=test npm run dist && jest --coverage",
     "jest": "NODE_ENV=test npm run dist && jest",
     "dist": "NODE_ENV=production ./node_modules/.bin/babel lib -d dist",
-    "test_debug": "NODE_ENV=test node --inspect node_modules/.bin/jest"
+    "test_debug": "NODE_ENV=test node --inspect node_modules/.bin/jest --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-redux": "^5"
   },
   "dependencies": {
+    "lodash.debounce": "^4.0.8",
     "react-redux-api-tools": "^2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rel-events",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The relevant React Events Library. Events framework based on redux to decouple our from business logic and make state management easy.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fixes #22 

This PR introduces a new feature: debouncing Events.

If you want to make an event debouceable, you now can just pass a `debounce: true` flag when instantiating a new Event. You may optionally customize the `debounceDelay` to a specific amount of miliseconds.

For debouncing, we're using lodash's debounce implementation.